### PR TITLE
Provide npm package via `dnt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _bin
 _site
+npm

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,6 @@
   },
   "lock": false,
   "fmt": {
-    "exclude": ["CHANGELOG.md"]
+    "exclude": ["CHANGELOG.md", "npm"]
   }
 }

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -3,12 +3,10 @@ import { build, emptyDir } from "https://deno.land/x/dnt/mod.ts";
 await emptyDir("./npm");
 
 await build({
+  test: false,
   entryPoints: ["./mod.ts"],
   outDir: "./npm",
-  shims: {
-    deno: true,
-    undici: "dev",
-  },
+  shims: { deno: true },
   compilerOptions: { target: "ES2022" },
   scriptModule: false,
   package: {

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -3,7 +3,6 @@ import { build, emptyDir } from "https://deno.land/x/dnt/mod.ts";
 await emptyDir("./npm");
 
 await build({
-  test: false,
   entryPoints: ["./mod.ts"],
   outDir: "./npm",
   shims: { deno: true },

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -20,7 +20,6 @@ await build({
     bugs: "https://github.com/oscarotero/vento/issues",
   },
   postBuild() {
-    Deno.copyFileSync("deno.json", "npm/esm/deno.json");
     Deno.copyFileSync("LICENSE", "npm/LICENSE");
     Deno.copyFileSync("README.md", "npm/README.md");
   },

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -12,7 +12,7 @@ await build({
   compilerOptions: { target: "ES2022" },
   scriptModule: false,
   package: {
-    name: "vento",
+    name: "ventojs",
     version: Deno.args[0],
     description: "🌬 A minimal but powerful template engine",
     license: "MIT",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -11,7 +11,6 @@ await build({
   scriptModule: false,
   package: {
     name: "ventojs",
-    type: "module",
     version: Deno.args[0]?.replace(/^v/, ""),
     description: "🌬 A minimal but powerful template engine",
     license: "MIT",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,0 +1,27 @@
+import { build, emptyDir } from "https://deno.land/x/dnt/mod.ts";
+
+await emptyDir("./npm");
+
+await build({
+  entryPoints: ["./mod.ts"],
+  outDir: "./npm",
+  shims: {
+    deno: true,
+    undici: "dev",
+  },
+  compilerOptions: { target: "ES2022" },
+  scriptModule: false,
+  package: {
+    name: "vento",
+    version: Deno.args[0],
+    description: "🌬 A minimal but powerful template engine",
+    license: "MIT",
+    repository: "github:oscarotero/vento",
+    bugs: "https://github.com/oscarotero/vento/issues",
+  },
+  postBuild() {
+    Deno.copyFileSync("deno.json", "npm/esm/deno.json");
+    Deno.copyFileSync("LICENSE", "npm/LICENSE");
+    Deno.copyFileSync("README.md", "npm/README.md");
+  },
+});

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -15,6 +15,7 @@ await build({
     description: "🌬 A minimal but powerful template engine",
     license: "MIT",
     repository: "github:oscarotero/vento",
+    homepage: "https://oscarotero.github.io/vento/",
     bugs: "https://github.com/oscarotero/vento/issues",
   },
   postBuild() {

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -11,6 +11,7 @@ await build({
   scriptModule: false,
   package: {
     name: "ventojs",
+    type: "module",
     version: Deno.args[0]?.replace(/^v/, ""),
     description: "🌬 A minimal but powerful template engine",
     license: "MIT",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -11,7 +11,7 @@ await build({
   scriptModule: false,
   package: {
     name: "ventojs",
-    version: Deno.args[0],
+    version: Deno.args[0]?.replace(/^v/, ""),
     description: "🌬 A minimal but powerful template engine",
     license: "MIT",
     repository: "github:oscarotero/vento",

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -96,15 +96,20 @@ Deno.test("Print trim", async () => {
   });
 });
 
-Deno.test("Print async filters", async () => {
-  const url = new URL("../deno.json", import.meta.url).href;
-  const expected = JSON.stringify(
-    JSON.parse(Deno.readTextFileSync(new URL(url))),
-  );
-
-  await test({
-    template: `{{ url |> await fetch |> await json |> JSON.stringify }}`,
-    expected,
-    data: { url },
-  });
+Deno.test({
+  name: "Print async filters",
+  // @ts-ignore only used to detect node.js
+  ignore: globalThis?.process?.release?.name === "node",
+  fn: async () => {
+    const url = new URL("../deno.json", import.meta.url).href;
+    const expected = JSON.stringify(
+      JSON.parse(Deno.readTextFileSync(new URL(url))),
+    );
+  
+    await test({
+      template: `{{ url |> await fetch |> await json |> JSON.stringify }}`,
+      expected,
+      data: { url },
+    });
+  }
 });

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -105,11 +105,11 @@ Deno.test({
     const expected = JSON.stringify(
       JSON.parse(Deno.readTextFileSync(new URL(url))),
     );
-  
+
     await test({
       template: `{{ url |> await fetch |> await json |> JSON.stringify }}`,
       expected,
       data: { url },
     });
-  }
+  },
 });

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -97,7 +97,7 @@ Deno.test("Print trim", async () => {
 });
 
 Deno.test("Print async filters", async () => {
-  const url = import.meta.resolve("../deno.json");
+  const url = new URL("../deno.json", import.meta.url).href;
   const expected = JSON.stringify(
     JSON.parse(Deno.readTextFileSync(new URL(url))),
   );


### PR DESCRIPTION
It is currently stuck in the "Print async filters" test of `print.test.ts`.

undici for node.js does not support `file://` url, will get a "not implemented yet" error (https://github.com/nodejs/undici/issues/2144)

Run the dnt build: `deno run -A scripts/build_npm.ts <version>`