### PR TITLE
fix: use correct key for cache queries

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -148,10 +148,10 @@ export class Environment {
       const { source, data } = await this.options.loader.load(path);
       const template = this.compile(source, path, data);
 
-      this.cache.set(file, template);
+      this.cache.set(path, template);
     }
 
-    return this.cache.get(file)!;
+    return this.cache.get(path)!;
   }
 
   compileTokens(


### PR DESCRIPTION
Somehow, when querying its cache for any already compiled templates, Vento uses the *path* when in actuality the templates are stored under the *file*. 

`undefined` shenanigans ensued.