### PR TITLE
docs: fix vscode quick install, fix links to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ First, let's take a look at this syntax example:
 
 ## Getting started
 
-See [Getting started](https://vento.js.org/get-started/) on the docs.
+See [Getting started](https://vento.js.org/getting-started/) on the docs.
 
-## Visual Studio Code support
+## Editor support
 
-[Vento Template Support for VS Code](https://marketplace.visualstudio.com/items?itemName=oscarotero.vento-syntax)
-enables syntax highlighting and Vento snippets.
+See [Editor integrations](https://vento.js.org/editor-integrations/) on the
+docs.

--- a/docs/editor-integrations.md
+++ b/docs/editor-integrations.md
@@ -2,8 +2,7 @@
 
 ## Visual Studio Code
 
-[The Vento extension for VS Code](https://marketplace.visualstudio.com/items?itemName=oscarotero.vento-syntax)
+The [Vento for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=oscarotero.vento-syntax) extension
 enables syntax highlighting and provides some useful snippets.
 
-[**Quick Install**](vscode:extension/oscarotero.vento-syntax){role="button"
-.button}
+[**Quick Install**](vscode:extension/oscarotero.vento-syntax){role="button" .button}


### PR DESCRIPTION
Oops! Fixes and adds a link to the website, and fixes the quick install button for the vscode extension.