### PR TITLE
chore: disable prettier formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deno.enable": true,
   "deno.unstable": true,
-  "deno.importMap": "./docs/deno.json"
+  "deno.importMap": "./docs/deno.json",
+  "prettier.enable": false
 }


### PR DESCRIPTION
Just like the title says. This only disables it in VSCode though, so would ignoring all files in a `.prettierignore` be a better solution?