### PR TITLE
Add `cache` option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ const env = vento({
   useWith: true,
   includes: Deno.cwd(),
   autoescape: false,
+  cache: true,
 });
 ```
 
@@ -83,6 +84,16 @@ const result = env.runString("{{ title |> safe }}", {
 ### includes
 
 The path of the directory that Vento will use to look for includes templates.
+
+### cache
+
+Set `false` to ignore the cache, and re-compile the template when loading.
+
+```js
+const env = vento({
+  cache: false, // default is true
+});
+```
 
 ## Filters
 

--- a/mod.ts
+++ b/mod.ts
@@ -18,6 +18,7 @@ export interface Options {
   useWith?: boolean;
   dataVarname?: string;
   autoescape?: boolean;
+  cache?: boolean;
 }
 
 export default function (options: Options = {}) {
@@ -30,6 +31,7 @@ export default function (options: Options = {}) {
     dataVarname: options.dataVarname || "it",
     autoescape: options.autoescape ?? false,
     useWith: options.useWith ?? true,
+    cache: options.cache ?? true,
   });
 
   // Register basic plugins


### PR DESCRIPTION
This adds an option to disable the cache, useful if you want to iterate on templates in dev-time. The cache is still set (template internals still use them), but cache hits are ignored.