### PR TITLE
Add whitespace options and `+` trim marker

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,30 @@ const result = env.runString("{{ title |> safe }}", {
 
 The path of the directory that Vento will use to look for includes templates.
 
+### trimTags
+
+Configures the default whitespace control.
+
+ - `false` - no trimming. This is the default.
+ - `"all"` - remove all whitespace
+
+```js
+const env = vento({
+  trimTags: "all",
+});
+```
+
+You can also configure the left and right trims separately:
+
+```js
+const env = vento({
+  trimTags: {
+    left: "all",
+    right: false,
+  },
+});
+```
+
 ## Filters
 
 Filters are custom functions to transform the content.

--- a/mod.ts
+++ b/mod.ts
@@ -12,12 +12,15 @@ import exportTag from "./plugins/export.ts";
 import echoTag from "./plugins/echo.ts";
 import escape from "./plugins/escape.ts";
 import unescape from "./plugins/unescape.ts";
+import { TrimTagOptions } from "./src/tokenizer.ts";
+import { TrimType } from "./src/tokenizer.ts";
 
 export interface Options {
   includes?: string | Loader;
   useWith?: boolean;
   dataVarname?: string;
   autoescape?: boolean;
+  trimTags?: TrimType | TrimTagOptions;
 }
 
 export default function (options: Options = {}) {
@@ -30,6 +33,12 @@ export default function (options: Options = {}) {
     dataVarname: options.dataVarname || "it",
     autoescape: options.autoescape ?? false,
     useWith: options.useWith ?? true,
+    trimTags: typeof options.trimTags === "object"
+      ? options.trimTags
+      : {
+        left: options.trimTags ?? false,
+        right: options.trimTags ?? false,
+      },
   });
 
   // Register basic plugins

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,6 +1,7 @@
 import tokenize, { Token } from "./tokenizer.ts";
 
 import type { Loader } from "./loader.ts";
+import { TrimTagOptions } from "./tokenizer.ts";
 
 export interface TemplateResult {
   content: string;
@@ -49,6 +50,7 @@ export interface Options {
   dataVarname: string;
   autoescape: boolean;
   useWith: boolean;
+  trimTags: TrimTagOptions;
 }
 
 export class Environment {
@@ -124,7 +126,7 @@ export class Environment {
     defaults?: Record<string, unknown>,
     sync = false,
   ): Template | TemplateSync {
-    const result = tokenize(source);
+    const result = tokenize(source, this.options.trimTags);
     let { tokens } = result;
     const { position, error } = result;
 

--- a/test/tokenizer.test.ts
+++ b/test/tokenizer.test.ts
@@ -116,7 +116,7 @@ Deno.test("Tokenizer (auto both trims)", () => {
   assertEquals(tokens, [
     ["string", "<h1>", 0],
     ["tag", "message", 5],
-    ["string", "</h1>", 19],
+    ["string", "</h1>", 18],
   ]);
 });
 
@@ -125,8 +125,8 @@ Deno.test("Tokenizer (preserve left)", () => {
   const { tokens } = tokenize(code, { left: "all", right: "all" });
   assertEquals(tokens, [
     ["string", "<h1>      ", 0],
-    ["tag", "message", 5],
-    ["string", "</h1>", 19],
+    ["tag", "message", 10],
+    ["string", "</h1>", 24],
   ]);
 });
 
@@ -135,8 +135,8 @@ Deno.test("Tokenizer (preserve right)", () => {
   const { tokens } = tokenize(code, { left: "all", right: "all" });
   assertEquals(tokens, [
     ["string", "<h1>", 0],
-    ["tag", "message", 5],
-    ["string", " </h1>", 19],
+    ["tag", "message", 10],
+    ["string", " </h1>", 24],
   ]);
 });
 
@@ -145,8 +145,8 @@ Deno.test("Tokenizer (preserve both)", () => {
   const { tokens } = tokenize(code, { left: "all", right: "all" });
   assertEquals(tokens, [
     ["string", "<h1>      ", 0],
-    ["tag", "message", 5],
-    ["string", " </h1>", 19],
+    ["tag", "message", 10],
+    ["string", " </h1>", 25],
   ]);
 });
 

--- a/test/tokenizer.test.ts
+++ b/test/tokenizer.test.ts
@@ -90,6 +90,66 @@ Deno.test("Tokenizer (both trims)", () => {
   ]);
 });
 
+Deno.test("Tokenizer (auto left trim)", () => {
+  const code = `<h1> {{- message }} </h1>`;
+  const { tokens } = tokenize(code, { left: "all", right: false });
+  assertEquals(tokens, [
+    ["string", "<h1>", 0],
+    ["tag", "message", 5],
+    ["string", " </h1>", 19],
+  ]);
+});
+
+Deno.test("Tokenizer (auto right trim)", () => {
+  const code = `<h1> {{message -}} </h1>`;
+  const { tokens } = tokenize(code, { left: false, right: "all" });
+  assertEquals(tokens, [
+    ["string", "<h1> ", 0],
+    ["tag", "message", 5],
+    ["string", "</h1>", 18],
+  ]);
+});
+
+Deno.test("Tokenizer (auto both trims)", () => {
+  const code = `<h1> {{ message }} </h1>`;
+  const { tokens } = tokenize(code, { left: "all", right: "all" });
+  assertEquals(tokens, [
+    ["string", "<h1>", 0],
+    ["tag", "message", 5],
+    ["string", "</h1>", 19],
+  ]);
+});
+
+Deno.test("Tokenizer (preserve left)", () => {
+  const code = `<h1>      {{+ message }} </h1>`;
+  const { tokens } = tokenize(code, { left: "all", right: "all" });
+  assertEquals(tokens, [
+    ["string", "<h1>      ", 0],
+    ["tag", "message", 5],
+    ["string", "</h1>", 19],
+  ]);
+});
+
+Deno.test("Tokenizer (preserve right)", () => {
+  const code = `<h1>      {{ message +}} </h1>`;
+  const { tokens } = tokenize(code, { left: "all", right: "all" });
+  assertEquals(tokens, [
+    ["string", "<h1>", 0],
+    ["tag", "message", 5],
+    ["string", " </h1>", 19],
+  ]);
+});
+
+Deno.test("Tokenizer (preserve both)", () => {
+  const code = `<h1>      {{+ message +}} </h1>`;
+  const { tokens } = tokenize(code, { left: "all", right: "all" });
+  assertEquals(tokens, [
+    ["string", "<h1>      ", 0],
+    ["tag", "message", 5],
+    ["string", " </h1>", 19],
+  ]);
+});
+
 Deno.test("Tokenizer (comment)", () => {
   const code = `<h1> {{# {{ message }} #}} </h1>`;
   const { tokens } = tokenize(code);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -86,9 +86,9 @@ export class FileLoader implements Loader {
 
   resolve(from: string, file: string): string {
     if (file.startsWith(".")) {
-      return path.join(path.dirname(from), file);
+      return path.join(path.dirname(from), file).replace(/\\/g, "/");
     }
 
-    return path.join("/", file);
+    return path.join("/", file).replace(/\\/g, "/");
   }
 }


### PR DESCRIPTION
This adds a new option called `trimTags`, which lets you set the default whitespace behavior for tags. Additionally, you might want to preserve whitespace when you have this enabled, so the `+` marker was also added. Added tests for it too.

I've also left room for expanding the whitespace trimming behavior, for now you have "all" or false. Might be nice in the future to have "minimize", which would leave one space or newline character instead of trimming it all away.

Here's an example:

```js
const env = vento({
  trimTags: "all",
});

// If you want more control:
const env = vento({
  trimTags: {
    left: "all",
    right: false,
  },
});
```
If enabled, you can use the `+` marker to preserve whitespace.
```nunjucks
Hello, {{+ name }}!
```