### PR TITLE
Fix: Convert any value to string when escaping

### DIFF
--- a/plugins/escape.ts
+++ b/plugins/escape.ts
@@ -3,6 +3,7 @@ import type { Environment } from "../src/environment.ts";
 
 export default function () {
   return (env: Environment) => {
-    env.filters.escape = html.escape;
+    // deno-lint-ignore no-explicit-any
+    env.filters.escape = (value: any) => html.escape(value.toString());
   };
 }

--- a/plugins/escape.ts
+++ b/plugins/escape.ts
@@ -4,6 +4,7 @@ import type { Environment } from "../src/environment.ts";
 export default function () {
   return (env: Environment) => {
     // deno-lint-ignore no-explicit-any
-    env.filters.escape = (value: any) => html.escape(value.toString());
+    env.filters.escape = (value: any) => value ? html.escape(value.toString()) : "";
   };
 }
+

--- a/plugins/escape.ts
+++ b/plugins/escape.ts
@@ -4,7 +4,7 @@ import type { Environment } from "../src/environment.ts";
 export default function () {
   return (env: Environment) => {
     // deno-lint-ignore no-explicit-any
-    env.filters.escape = (value: any) => value ? html.escape(value.toString()) : "";
+    env.filters.escape = (value: any) =>
+      value ? html.escape(value.toString()) : "";
   };
 }
-

--- a/plugins/unescape.ts
+++ b/plugins/unescape.ts
@@ -3,6 +3,8 @@ import type { Environment } from "../src/environment.ts";
 
 export default function () {
   return (env: Environment) => {
-    env.filters.unescape = html.unescape;
+    // deno-lint-ignore no-explicit-any
+    env.filters.unescape = (value: any) =>
+      value ? html.unescape(value.toString()) : "";
   };
 }

--- a/test/escape.test.ts
+++ b/test/escape.test.ts
@@ -35,3 +35,33 @@ Deno.test("Escape by default", async () => {
     expected: "&lt;h1&gt;Hello world&lt;/h1&gt;",
   });
 });
+
+Deno.test("Escape non-string", async () => {
+  await test({
+    template: `
+    {{ 100 |> escape }}
+    `,
+    expected: "100",
+  });
+  testSync({
+    template: `
+    {{ 100 |> escape }}
+    `,
+    expected: "100",
+  });
+});
+
+Deno.test("Escape undefined", async () => {
+  await test({
+    template: `
+    {{ undefined |> escape }}
+    `,
+    expected: "",
+  });
+  testSync({
+    template: `
+    {{ undefined |> escape }}
+    `,
+    expected: "",
+  });
+});

--- a/test/unescape.test.ts
+++ b/test/unescape.test.ts
@@ -15,7 +15,7 @@ Deno.test("Unescape filter", async () => {
   });
 });
 
-Deno.test("Escape by default", async () => {
+Deno.test("Unescape with escape by default", async () => {
   await test({
     options: {
       autoescape: true,
@@ -33,5 +33,35 @@ Deno.test("Escape by default", async () => {
     {{ "<h1>Hello world</h1>" |> unescape |> safe }}
     `,
     expected: "<h1>Hello world</h1>",
+  });
+});
+
+Deno.test("Unescape non-string", async () => {
+  await test({
+    template: `
+    {{ 100 |> unescape }}
+    `,
+    expected: "100",
+  });
+  testSync({
+    template: `
+    {{ 100 |> unescape }}
+    `,
+    expected: "100",
+  });
+});
+
+Deno.test("Unescape undefined", async () => {
+  await test({
+    template: `
+    {{ undefined |> unescape }}
+    `,
+    expected: "",
+  });
+  testSync({
+    template: `
+    {{ undefined |> unescape }}
+    `,
+    expected: "",
   });
 });


### PR DESCRIPTION
Ran into this issue when using autoescape (but this also affects escaping values in general). This ensures any value that is passed into the filter is converted into a string. `html.escape` expects a string input, it doesn't convert the value automatically for you.

For example, this wouldn't work:

```js
const env = vento({
  autoescape: true
});

const res = env.run("my-template.vto", { number: 10 });
```

```error
  Error: Error in the template my-template.vto:11:5

  {{ number }}

  > str.replaceAll is not a function
```