### PR TITLE
Support empty and more complex function arguments

### DIFF
--- a/plugins/function.ts
+++ b/plugins/function.ts
@@ -21,7 +21,7 @@ function functionTag(
   }
 
   const match = code.match(
-    /^(export\s+)?(async\s+)?function\s+(\w+)\s*(\([^)]+\))?$/,
+    /^(export\s+)?(async\s+)?function\s+(\w+)\s*(\([^]*\))?$/,
   );
 
   if (!match) {

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -133,6 +133,17 @@ Deno.test("Function scope is respected", async () => {
     `,
     expected: "No name / Hello world!",
   });
+
+  await test({
+    template: `
+    {{ function hello() }}
+    Hello world
+    {{ /function }}
+
+    {{ hello() }}
+    `,
+    expected: "Hello world",
+  });
 });
 
 Deno.test("Function with filters", async () => {
@@ -189,5 +200,24 @@ Deno.test("Function with autoescape", async () => {
     options: {
       autoescape: true,
     },
+  });
+});
+
+Deno.test("Function with complex arguments", async () => {
+  await test({
+    template: `
+    {{ function greet(name) -}}
+      Hello {{ name }}
+    {{- /function }}
+    {{ function hello(
+      {suffix = ' (hi)'} = {},
+      greeting = greet('world'),
+    ) }}
+      {{ greeting }}{{ suffix }}
+    {{ /function }}
+
+    {{ hello() }}
+    `,
+    expected: "Hello world (hi)",
   });
 });


### PR DESCRIPTION
Previously, the `{{ function }}` tag did not support something like `{{ function hello() }}` since there was nothing within the parentheses. It probably makes more sense to allow it since functions with arguments must use parentheses and so people might want to use parentheses for consistency.

Additionally, arguments containing `)` anywhere were disallowed, but this is not a necessary restriction since the regular expression forces the arguments to be captured in their entirety by requiring the closing `\)` to be matched next to the end `$` of the tag.