### PR TITLE
Support absolute paths in file loader

### DIFF
--- a/loaders/file.ts
+++ b/loaders/file.ts
@@ -25,7 +25,7 @@ export class FileLoader implements Loader {
       return path.join(path.dirname(from), file);
     }
 
-    if (file.startsWith("/") || file.startsWith(this.#root)) {
+    if (path.isAbsolute(file) || file.startsWith(this.#root)) {
       return file;
     }
 


### PR DESCRIPTION
Currently absolute paths get appended onto the cwd and throw an error, which I doubt was intended