### PR TITLE
Autotrimming improvements

### DIFF
--- a/plugins/auto_trim.ts
+++ b/plugins/auto_trim.ts
@@ -18,8 +18,8 @@ export const defaultTags = [
   "import",
 ];
 
-const LEADING_WHITESPACE = /(^|\n)[ \t]+$/
-const TRAILING_WHITESPACE = /^[ \t]*\r?\n/
+const LEADING_WHITESPACE = /(^|\n)[ \t]+$/;
+const TRAILING_WHITESPACE = /^[ \t]*\r?\n/;
 
 export type AutoTrimOptions = { tags: string[] };
 
@@ -36,28 +36,28 @@ export function autoTrim(tokens: Token[], options: AutoTrimOptions) {
     const token = tokens[i];
     const [type, code] = token;
 
-    let needsTrim = false
-    if(type === "comment"){
-      needsTrim = true
-    } else if(type === "tag"){
+    let needsTrim = false;
+    if (type === "comment") {
+      needsTrim = true;
+    } else if (type === "tag") {
       needsTrim = options.tags.some((tag) => {
-        if(!code.startsWith(tag)) return false
-        return /\s/.test(code[tag.length] ?? " ")
-      })
+        if (!code.startsWith(tag)) return false;
+        return /\s/.test(code[tag.length] ?? " ");
+      });
     }
 
-    if(!needsTrim) continue;
+    if (!needsTrim) continue;
 
     // Remove leading horizontal space
     const previous = tokens[i - 1];
     previous[1] = previous[1].replace(LEADING_WHITESPACE, "$1");
 
     // Skip "filter" tokens to find the next "string" token
-    for(let j = i + 1; j < tokens.length; j++){
-      if(tokens[j][0] === "filter") continue;
-      if(tokens[j][0] !== "string") break;
+    for (let j = i + 1; j < tokens.length; j++) {
+      if (tokens[j][0] === "filter") continue;
+      if (tokens[j][0] !== "string") break;
       // Remove trailing horizontal space + newline
-      const next = tokens[j]
+      const next = tokens[j];
       next[1] = next[1].replace(TRAILING_WHITESPACE, "");
     }
   }

--- a/test/auto_trim.test.ts
+++ b/test/auto_trim.test.ts
@@ -68,7 +68,7 @@ Deno.test("Autotrim (no next tokens)", () => {
 
 Deno.test("Autotrim usage", async () => {
   await test({
-    init: env => env.use(autoTrim()),
+    init: (env) => env.use(autoTrim()),
     template: `
     Hello
     {{ set name = "world" }}
@@ -79,7 +79,7 @@ Deno.test("Autotrim usage", async () => {
     expected: "Hello\n      world!",
   });
   await test({
-    init: env => env.use(autoTrim()),
+    init: (env) => env.use(autoTrim()),
     template: `
     Hello
     {{ set name = "world" }}
@@ -89,7 +89,7 @@ Deno.test("Autotrim usage", async () => {
     expected: "Hello\n    world",
   });
   await test({
-    init: env => env.use(autoTrim()),
+    init: (env) => env.use(autoTrim()),
     template: `
     Hello
     {{# Hello world #}} {{ set name = "world" }}
@@ -98,7 +98,7 @@ Deno.test("Autotrim usage", async () => {
     expected: "Hello\n    world",
   });
   await test({
-    init: env => env.use(autoTrim()),
+    init: (env) => env.use(autoTrim()),
     template: `
     Hello
     {{ set name = "world" |> trim }}


### PR DESCRIPTION
Autotrimming was done asymmetrically across comments and tags; specifically, comments trimmed a newline character on their left, while tags trimmed one on their right. This can create edge cases in certain scenarios.

Additionally, filters weren't handled properly. With tag autotrimming, the next token was taken to trim whitespace from, but this is incorrect if the next token is a filter. Instead, we need to skip the filters and trim the next "string"-type token.

A few tests have been added as well to solidify this behavior.