### PR TITLE
Add missing break statement

### DIFF
--- a/plugins/auto_trim.ts
+++ b/plugins/auto_trim.ts
@@ -59,6 +59,7 @@ export function autoTrim(tokens: Token[], options: AutoTrimOptions) {
       // Remove trailing horizontal space + newline
       const next = tokens[j];
       next[1] = next[1].replace(TRAILING_WHITESPACE, "");
+      break;
     }
   }
 }


### PR DESCRIPTION
Just noticed that there's a `break` statement missing here. This is not problematic per se, since a string token should never be followed up with another string token nor a filter, but this is not something the code should rely on. Adding it here to avoid confusion or bugs in the future.