### PR TITLE
Fix `oposite` -> `opposite` typo in pipes docs

### DIFF
--- a/docs/4.syntax/2.pipes.md
+++ b/docs/4.syntax/2.pipes.md
@@ -24,7 +24,7 @@ The `escape` filter allows to escape HTML entities:
 {{ "<h1>Hello, world!</h1>" |> escape }}
 ```
 
-The `unescape` filter is the oposite of `escape`:
+The `unescape` filter is the opposite of `escape`:
 
 ```vto
 {{ "&lt;h1&gt;Hello, world!&lt;/h1&gt;" |> unescape }}


### PR DESCRIPTION
Line 27 of `docs/4.syntax/2.pipes.md` has `oposite` (missing p).