### PR TITLE
Support classic for loops

### DIFF
--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -41,6 +41,14 @@ function forTag(
   let var2: string | undefined = undefined;
   let collection = "";
 
+  if (tagCode.startsWith("var ") || tagCode.startsWith("let ")) {
+    return `
+      for ${aw || ""}(${tagCode}) {
+        ${env.compileTokens(tokens, output, "/for").join("\n")}
+      }
+    `;
+  }
+
   if (tagCode.startsWith("[") || tagCode.startsWith("{")) {
     [var1, tagCode] = getDestructureContent(tagCode);
   } else {

--- a/test/for.test.ts
+++ b/test/for.test.ts
@@ -277,6 +277,24 @@ Deno.test("For tag (destructured)", async () => {
   });
 });
 
+Deno.test("For tag (classic)", async () => {
+  await test({
+    template: `
+    {{ for let i = 0; i < 10; i += 2 }}{{ i }}{{ /for }}
+    `,
+    expected: "02468",
+  });
+
+  await test({
+    template: `
+    {{ for var i = 0, j = 0; i < 10; i += 2, j += i -}}
+      {{ i }}({{ j }}) -
+    {{- /for }}
+    `,
+    expected: "0(0) -2(2) -4(6) -6(12) -8(20) -",
+  });
+});
+
 Deno.test("For tag with break and continue", async () => {
   await test({
     template: `


### PR DESCRIPTION
Supports classic initializer-condition-incrementer-style for loops. They must start with either `let ` or `var ` to disambiguate between for...of. The latter currently doesn't support `let` or `var` (or `const`) keywords so this is a backwards-compatible change that has minimal performance impact.

Resolves https://github.com/ventojs/vento/issues/173