### PR TITLE
No infinite nesting

### DIFF
--- a/core/environment.ts
+++ b/core/environment.ts
@@ -58,17 +58,17 @@ export interface Options {
   autoescape: boolean;
   autoDataVarname: boolean;
   strict: boolean;
+  maxRenderConcurrency: number;
 }
 
 export class Environment {
-  MAX_SIMULTANEOUS_TEMPLATES: number = 10_000;
   cache: Map<string, Template | Promise<Template>> = new Map();
   options: Options;
   tags: Tag[] = [];
   tokenPreprocessors: TokenPreprocessor[] = [];
   filters: Record<string, Filter> = {};
   #tempVariablesCreated = 0;
-  #concurrentRuns = 0;
+  #renderConcurrency = 0;
   utils: Record<string, unknown> = {
     callMethod,
     createError,
@@ -91,7 +91,7 @@ export class Environment {
     position?: number,
   ): Promise<TemplateResult> {
     const template = await this.load(file, from, position);
-    if (this.#concurrentRuns >= this.MAX_SIMULTANEOUS_TEMPLATES) {
+    if (this.#renderConcurrency >= this.options.maxRenderConcurrency) {
       throw createError(
         Error(
           "Too many templates are running simultaneously.\n" +
@@ -101,9 +101,9 @@ export class Environment {
         position,
       );
     }
-    this.#concurrentRuns++;
+    this.#renderConcurrency++;
     const result = await template(data);
-    this.#concurrentRuns--;
+    this.#renderConcurrency--;
     return result;
   }
 

--- a/core/environment.ts
+++ b/core/environment.ts
@@ -61,12 +61,14 @@ export interface Options {
 }
 
 export class Environment {
+  MAX_SIMULTANEOUS_TEMPLATES: number = 10_000;
   cache: Map<string, Template | Promise<Template>> = new Map();
   options: Options;
   tags: Tag[] = [];
   tokenPreprocessors: TokenPreprocessor[] = [];
   filters: Record<string, Filter> = {};
   #tempVariablesCreated = 0;
+  #concurrentRuns = 0;
   utils: Record<string, unknown> = {
     callMethod,
     createError,
@@ -89,7 +91,20 @@ export class Environment {
     position?: number,
   ): Promise<TemplateResult> {
     const template = await this.load(file, from, position);
-    return await template(data);
+    if (this.#concurrentRuns >= this.MAX_SIMULTANEOUS_TEMPLATES) {
+      throw createError(
+        Error(
+          "Too many templates are running simultaneously.\n" +
+            "This is likely caused by an infinite loop in template nesting.",
+        ),
+        template,
+        position,
+      );
+    }
+    this.#concurrentRuns++;
+    const result = await template(data);
+    this.#concurrentRuns--;
+    return result;
   }
 
   async runString(

--- a/mod.ts
+++ b/mod.ts
@@ -8,6 +8,7 @@ export interface Options {
   dataVarname?: string;
   autoescape?: boolean;
   strict?: boolean;
+  maxRenderConcurrency?: number;
 }
 
 export default function (options: Options = {}): Environment {
@@ -23,6 +24,7 @@ export default function (options: Options = {}): Environment {
     autoescape: options.autoescape ?? false,
     autoDataVarname: options.autoDataVarname ?? true,
     strict: options.strict ?? false,
+    maxRenderConcurrency: options.maxRenderConcurrency ?? 10_000,
   });
 
   // Register the default plugins

--- a/test/include.test.ts
+++ b/test/include.test.ts
@@ -1,4 +1,4 @@
-import { test } from "./utils.ts";
+import { test, testThrows } from "./utils.ts";
 
 Deno.test("Include tag", async () => {
   await test({
@@ -323,6 +323,39 @@ Deno.test("Include tag with semi-ambiguous JS objects", async () => {
     },
     data: {
       name: "Vento",
+    },
+  });
+});
+
+Deno.test("Include tag causing infinite nesting", async () => {
+  await test({
+    template: `
+    {{ include "/nest.vto" { depth: 9_999 } }}
+    `,
+    expected: "Bottom reached!",
+    includes: {
+      "/nest.vto": `
+        {{ if depth > 0 }}
+          {{ include "/nest.vto" { depth: depth - 1 } }}
+        {{ else }}
+          Bottom reached!
+        {{ /if }}
+      `,
+    },
+  });
+
+  await testThrows({
+    template: `
+    {{ include "/nest.vto" { depth: 10_000 } }}
+    `,
+    includes: {
+      "/nest.vto": `
+        {{ if depth > 0 }}
+          {{ include "/nest.vto" { depth: depth - 1 } }}
+        {{ else }}
+          Bottom reached!
+        {{ /if }}
+      `,
     },
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,29 +20,33 @@ export interface TestOptions {
   options?: Options;
 }
 
-export async function testThrows(
-  options: Omit<TestOptions, "expected">,
+function getTest(
+  options: TestOptions,
 ) {
-  await assertRejects(async () => await test({ ...options, expected: "" }));
-}
-
-export async function test(options: TestOptions) {
   const env = tmpl({
     includes: new TestLoader(options.includes || {}),
     ...options.options,
   });
 
-  if (options.init) {
-    options.init(env);
-  }
+  options.init?.(env);
 
   if (options.filters) {
     for (const [name, filter] of Object.entries(options.filters)) {
       env.filters[name] = filter;
     }
   }
+  return async () => await env.runString(options.template, options.data);
+}
 
-  const result = await env.runString(options.template, options.data);
+export function testThrows(
+  options: Omit<TestOptions, "expected">,
+) {
+  assertRejects(getTest({ ...options, expected: "" }));
+}
+
+export async function test(options: TestOptions) {
+  const run = getTest(options);
+  const result = await run();
   assertEquals(result.content.trim(), options.expected.trim());
 }
 

--- a/web.ts
+++ b/web.ts
@@ -8,6 +8,7 @@ export interface Options {
   dataVarname?: string;
   autoescape?: boolean;
   strict?: boolean;
+  maxRenderConcurrency?: number;
 }
 
 export default function (options: Options): Environment {
@@ -23,6 +24,7 @@ export default function (options: Options): Environment {
     autoescape: options.autoescape ?? false,
     autoDataVarname: options.autoDataVarname ?? true,
     strict: options.strict ?? false,
+    maxRenderConcurrency: options.maxRenderConcurrency ?? 10_000,
   });
 
   // Register the default plugins


### PR DESCRIPTION
This is mostly intended to prevent infinite nesting, but really detects simultaneously running templates in general. However, the latter is extremely unlikely unless the user is specifically rendering templates in parallel, since `{{ include }}` and `{{ layout }}` tags always `await` their run before continuing to render the rest of the template.

Suggestions for other names are welcome, personally I'm not a huge fan of `MAX_SIMULTANEOUS_TEMPLATES` but this is more accurate than something like `MAX_NESTING` since it _can_ hypothetically trigger from concurrent non-nested templates.

As a sidenote, this PR also includes a fix for `testThrows()`, which wouldn't fail a test if it ran without error but rendered something other than `""` (because then the underlying `test()` call would throw an error since it failed to match `expected: ""`).

Resolves https://github.com/ventojs/vento/issues/180.