### PR TITLE
docs/editor-integration: Add info about importing Vento snippets into Neovim plugins

### DIFF
--- a/docs/3.editor-integrations.md
+++ b/docs/3.editor-integrations.md
@@ -38,6 +38,8 @@ require("nvim-treesitter.configs").setup({
 })
 ```
 
+If you also want Vento code snippets, you can install a snippet engine plugin that supports Visual Studio Code-style snippet JSON files, such as [LuaSnip](https://github.com/L3MON4D3/LuaSnip) or [mini.snippets](https://github.com/nvim-mini/mini.snippets), and import Vento snippets from the [`vento.json`](https://github.com/ventojs/vscode-vento/blob/main/snippets/vento.json) source file of the official Vento extension for Visual Studio Code.
+
 ## Zed
 
 The [Vento extension for Zed](https://github.com/dz4k/zed-vento), created and maintained by Deniz Akşimşek, provides syntax


### PR DESCRIPTION
This PR aims to add information about how to add Vento code snippets to Neovim through a snippet plugin that supports Visual Studio Code-style snippet JSON file, and importing snippets from the existing [`vento.json`](https://github.com/ventojs/vscode-vento/blob/main/snippets/vento.json) from Vento's official VS Code extension.